### PR TITLE
Re-name plugin to cordova-plugin-applicationstate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "co.mylonas.cordova.applicationstate",
-  "version": "0.0.2",
+  "name": "cordova-plugin-applicationstate",
+  "version": "0.0.3",
   "description": "applicationstate",
   "cordova": {
-    "id": "co.mylonas.cordova.applicationstate",
+    "id": "cordova-plugin-applicationstate",
     "platforms": [
       "ios",
       "android"

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-		id="co.mylonas.cordova.applicationstate" version="0.0.2">
+		id="cordova-plugin-applicationstate" version="0.0.3">
 	<name>Application State</name>
 	<description>Application State</description>
 


### PR DESCRIPTION
This makes the plugin npm-friendly.  I'm seeing install failures on latest cordova.  Re-naming the plugin fixes this issue.

You'll also be able to publish your plugin to npm now.

```
Discovered plugin "co.mylonas.cordova.applicationstate" in config.xml. Adding it to the project
Failed to restore plugin "co.mylonas.cordova.applicationstate" from config.xml. You might need to try adding it again. Error: Failed to fetch plugin git+https://github.com/leomylonas/cordova-plugin-applicationstate.git via registry.
Probably this is either a connection problem, or plugin spec is incorrect.
Check your connection and plugin name/version/URL.
Failed to get absolute path to installed module
```
